### PR TITLE
Configure Android namespace to fix missing namespace issue on Gradle >= 8.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.pdftron.pdftronflutter'
+
     compileSdkVersion 33
 
     defaultConfig {


### PR DESCRIPTION
Fixes:

```
* What went wrong:
A problem occurred configuring project ':pdftron_flutter'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```

Aside from this, one should add this to the `gradle.properties` of the application (adding it to the library did not fix the issue):

`android.nonTransitiveRClass=false`

EDIT 2024-11-20: We found out PDFtron crashed in Flutter release mode, due to R8 being used in full mode by default as of Gradle 8. This fixed it for us:

`android.enableR8.fullMode=false`