### PR TITLE
Update Build Configuration and Resolve Compatibility Issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    namespace 'com.pdftron.pdftronflutter'
+
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 19

--- a/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
+++ b/android/src/main/java/com/pdftron/pdftronflutter/helpers/PluginUtils.java
@@ -59,7 +59,7 @@ import com.pdftron.pdf.widget.bottombar.builder.BottomBarBuilder;
 import com.pdftron.pdf.widget.toolbar.builder.AnnotationToolbarBuilder;
 import com.pdftron.pdf.widget.toolbar.builder.ToolbarButtonType;
 import com.pdftron.pdf.widget.toolbar.component.DefaultToolbars;
-import com.pdftron.pdftronflutter.R;
+import com.pdftron.pdf.tools.R;
 import com.pdftron.pdf.PDFDraw;
 
 import org.apache.commons.io.FileUtils;


### PR DESCRIPTION

- Added the Android namespace to resolve the missing namespace issue on Gradle version 8.x.x and above.  
- Updated the `compileSdk` to version 34 for compatibility with the latest Android API.  
- Removed the deprecated `compileSdkVersion` to align with modern Gradle practices.  
- Adjusted the path for generated resources to reference the correct location in the tools SDK.  