### PR TITLE
[iOS] Exposing apple pencil and smart highlighter for custom toolbar

### DIFF
--- a/ios/Classes/PdftronFlutterPlugin.m
+++ b/ios/Classes/PdftronFlutterPlugin.m
@@ -3819,6 +3819,12 @@
     else if ([key isEqualToString:PTPanToolKey]) {
         return [PTPanTool class];
     }
+    else if ([key isEqualToString:PTAnnotationSmartPenToolKey]) {
+        return [PTSmartPen class];
+    }
+    else if ([key isEqualToString:PTPencilKitDrawingToolKey]) {
+        return [PTPencilDrawingCreate class];
+    }
 
     return Nil;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdftron_flutter
 description: A convenience wrapper to build Flutter apps that use the PDFTron mobile SDK for smooth, flexible, and stand-alone document viewing.
-version: 1.0.1-39
+version: 1.0.1-40
 homepage: https://www.apryse.com
 repository: https://github.com/ApryseSDK/pdftron-flutter
 issue_tracker: https://github.com/ApryseSDK/pdftron-flutter/issues


### PR DESCRIPTION
Add support for apple pencil and smart highlighter in custom toolbar as calling this wouldn't show the tools in this dart toolbar:

```
var customToolbar = CustomToolbar(
    'myToolbar',
    'myToolbar',
    [
      Tools.annotationLasso,
      Tools.annotationSmartPen,
      Tools.pencilKitDrawing,
      Tools.annotationCreateFreeHand,
      Tools.annotationCreateFreeHighlighter,
      Tools.eraser,
      Tools.annotationCreateSignature,
      Tools.annotationCreateStamp,
    ],
    ToolbarIcons.favorite);
var annotationToolbars = [
  customToolbar,
];
    config.annotationToolbars = annotationToolbars;
```